### PR TITLE
Adding skipped status to CLI output

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-reporter-reportportal",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "description": "TestCafe reporter plugin for reportportal.io",
   "repository": "https://github.com/redfox256/testcafe-reporter-reportportal",
   "author": {

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ export default function () {
             const hasErr = !!testRunInfo.errs.length;
             const result = testRunInfo.skipped ? 'skipped' : hasErr ? 'failed' : 'passed';
         
-            const title = `[ ${result === 'passed' ? this.chalk.green.bold('✓') : this.chalk.red.bold('✖')} ] ${name}`;
+            const title = `[ ${result === 'passed' ? this.chalk.green.bold('✓') : result === 'skipped' ? this.chalk.blue.bold('-') : this.chalk.red.bold('✖')} ] ${name}`;
         
             this.setIndent(2)
                 .write(`${title}`)


### PR DESCRIPTION
Added a skipped status to the CLI output.
Originally, the status of skipped tests was showing as failed (red x)