### PR TITLE
Issue #13 - Don't fail test command when unable to connect to ReportPortal

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ REPORT_PORTAL_TAGS=Tag1, Tag2
 REPORT_PORTAL_DESCRIPTION=Run description
 ```
 
+Note, the above variables can also be set as environment variables through your terminal.
 
 When you use API, pass the reporter name to the `reporter()` method:
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ REPORT_PORTAL_TAGS=Tag1, Tag2
 REPORT_PORTAL_DESCRIPTION=Run description
 ```
 
+
 When you use API, pass the reporter name to the `reporter()` method:
 
 ```js

--- a/README.md
+++ b/README.md
@@ -36,8 +36,6 @@ REPORT_PORTAL_TAGS=Tag1, Tag2
 REPORT_PORTAL_DESCRIPTION=Run description
 ```
 
-Note, the above variables can also be set as environment variables through your terminal.
-
 When you use API, pass the reporter name to the `reporter()` method:
 
 ```js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-reporter-reportportal",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "description": "TestCafe reporter plugin for reportportal.io",
   "repository": "https://github.com/redfox256/testcafe-reporter-reportportal",
   "author": {

--- a/src/productreport.js
+++ b/src/productreport.js
@@ -27,7 +27,7 @@ export default class ProductReport {
             // console.log('You have successfully connected to the server.');
             // console.log(`You are using an account: ${response.full_name}`);
         }, (error) => {
-            console.log('Error connecting to ReportPortal, confirm that your details are correct.');
+            console.warn('Error connecting to ReportPortal, confirm that your details are correct.');
             console.dir(error);
             this.connected = false;
         });

--- a/src/productreport.js
+++ b/src/productreport.js
@@ -13,6 +13,7 @@ export default class ProductReport {
         this.description = typeof process.env.REPORT_PORTAL_DESCRIPTION === 'undefined' ? void 0 : process.env.REPORT_PORTAL_DESCRIPTION;
         this.tagsList = typeof process.env.REPORT_PORTAL_TAGS === 'undefined' ? void 0 : process.env.REPORT_PORTAL_TAGS.split(',');
         this.fixtureList = [];
+        this.connected = true;
 
         this.rpClient = new RPClient({
             token : process.env.REPORT_PORTAL_TOKEN,
@@ -22,15 +23,18 @@ export default class ProductReport {
         });
 
         this.rpClient.checkConnect().then((response) => {
+            this.connected = true;
             // console.log('You have successfully connected to the server.');
             // console.log(`You are using an account: ${response.full_name}`);
         }, (error) => {
             console.log('Error connecting to ReportPortal, confirm that your details are correct.');
             console.dir(error);
+            this.connected = false;
         });
     }
 
     startLaunch() {
+        if (!this.connected) return 'Unknown Launch ID';
         const launchObj = this.rpClient.startLaunch({
             name: this.launchName,
             description: this.description,
@@ -41,6 +45,7 @@ export default class ProductReport {
     }
 
     captureFixtureItem(launchId, fixtureName) {
+        if (!this.connected) return 'Unknown Test ID';
         const suiteObj = this.rpClient.startTestItem({
             name: fixtureName,
             type: 'SUITE'
@@ -51,6 +56,8 @@ export default class ProductReport {
     }
 
     captureTestItem(launchId, fixtureId, stepName, status, testRunInfo, parentSelf) {
+        if (!this.connected) return;
+
         var start_time = this.rpClient.helpers.now();
         const stepObj = this.rpClient.startTestItem({
             name: stepName,
@@ -102,6 +109,7 @@ export default class ProductReport {
     }
 
     finishFixture() {
+        if (!this.connected) return;     
         this.fixtureList.forEach((fixtureId, idx) => {
             this.rpClient.finishTestItem(fixtureId, {
                 end_time: this.rpClient.helpers.now()
@@ -110,6 +118,7 @@ export default class ProductReport {
     }
 
     finishLaunch(launchId) {
+        if (!this.connected) return;
         this.finishFixture();
         this.rpClient.finishLaunch(launchId, {
             end_time: this.rpClient.helpers.now()


### PR DESCRIPTION
Currently, when the connection to ReportPortal fails, the test command will also fail.
This PR changes that by skipping API calls to ReportPortal if the initial checkConnection fails. An error message is displayed initially, but no other messages / errors occur.