### PR TITLE
Executing reportTaskDone with async await

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -23,7 +23,7 @@ gulp.task('lint', function () {
 gulp.task('build', ['clean', 'lint'], function () {
     return gulp
         .src('src/**/*.js')
-        .pipe(babel())
+        .pipe(babel( { optional: ['runtime'] } ))
         .pipe(gulp.dest('lib'));
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-reporter-reportportal",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "description": "TestCafe reporter plugin for reportportal.io",
   "repository": "https://github.com/redfox256/testcafe-reporter-reportportal",
   "author": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "license": "MIT",
   "devDependencies": {
     "babel-eslint": "^4.0.10",
+    "babel-runtime": "^5.3.0",
     "callsite-record": "^3.2.0",
     "del": "^1.2.0",
     "gulp": "^3.9.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+const regeneratorRuntime = require('babel-runtime/regenerator');
 const ProductReport = require('./productreport');
 
 export default function () {
@@ -46,7 +47,7 @@ export default function () {
             this.productReport.captureTestItem(this.launchId, this.fixtureId, name, result, testRunInfo, self);
         },
         
-        reportTaskDone (endTime, passed) {
+        async reportTaskDone (endTime, passed) {
             const durationMs  = endTime - this.startTime;
             const durationStr = this.moment
                                     .duration(durationMs)
@@ -63,7 +64,7 @@ export default function () {
                 .write(footer)
                 .newline();
 
-            this.productReport.finishLaunch(this.launchId);
+            await this.productReport.finishLaunch(this.launchId);
         }
     };
 }

--- a/src/productreport.js
+++ b/src/productreport.js
@@ -108,19 +108,19 @@ export default class ProductReport {
         this.rpClient.finishTestItem(stepObj.tempId, testResult);
     }
 
-    finishFixture() {
+    async finishFixture() {
         if (!this.connected) return;     
-        this.fixtureList.forEach((fixtureId, idx) => {
-            this.rpClient.finishTestItem(fixtureId, {
+        this.fixtureList.forEach(async (fixtureId, idx) => {
+            await this.rpClient.finishTestItem(fixtureId, {
                 end_time: this.rpClient.helpers.now()
             });
         });
     }
 
-    finishLaunch(launchId) {
+    async finishLaunch(launchId) {
         if (!this.connected) return;
-        this.finishFixture();
-        this.rpClient.finishLaunch(launchId, {
+        await this.finishFixture();
+        await this.rpClient.finishLaunch(launchId, {
             end_time: this.rpClient.helpers.now()
         });
     }


### PR DESCRIPTION
Waiting for reportTaskDone to finish by adding async await modifiers. This is possible due to a recent push to TestCafe.