### PR TITLE
Fix "Cannot read property 'async' of undefined"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-reporter-reportportal",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "TestCafe reporter plugin for reportportal.io",
   "repository": "https://github.com/redfox256/testcafe-reporter-reportportal",
   "author": {
@@ -24,7 +24,6 @@
   "license": "MIT",
   "devDependencies": {
     "babel-eslint": "^4.0.10",
-    "babel-runtime": "^5.3.0",
     "callsite-record": "^3.2.0",
     "del": "^1.2.0",
     "gulp": "^3.9.0",
@@ -37,6 +36,7 @@
     "testcafe": "^0.2.0-alpha"
   },
   "dependencies": {
+    "babel-runtime": "^5.3.0",
     "dotenv": "^6.2.0",
     "envs": "^0.1.6",
     "reportportal-js-client": "^1.0.2",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-const regeneratorRuntime = require('babel-runtime/regenerator');
 const ProductReport = require('./productreport');
 
 export default function () {


### PR DESCRIPTION
Since version 1.0.25, there is an error message "Cannot read property 'async' of undefined" produced from reportTaskDone.
This happens because the dependency `babel-runtime` was defined as a devDependency instead of a dependency. 
This PR fixes that to include the required dependency with the bundle.