### PR TITLE
Add ReportPortal Link To CLI at `finishLaunch()`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-reporter-reportportal",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "description": "TestCafe reporter plugin for reportportal.io",
   "repository": "https://github.com/redfox256/testcafe-reporter-reportportal",
   "author": {

--- a/src/productreport.js
+++ b/src/productreport.js
@@ -71,7 +71,7 @@ export default class ProductReport {
 
                 const screenshotContent = fs.readFileSync(screenshot.screenshotPath);
 
-                this.rpClient.sendLog(stepObj.tempId, 
+                this.rpClient.sendLog(stepObj.tempId,
                     {
                         status: 'error',
                         message: 'Error Screenshot',
@@ -109,7 +109,7 @@ export default class ProductReport {
     }
 
     async finishFixture() {
-        if (!this.connected) return;     
+        if (!this.connected) return;
         this.fixtureList.forEach(async (fixtureId, idx) => {
             await this.rpClient.finishTestItem(fixtureId, {
                 end_time: this.rpClient.helpers.now()
@@ -120,8 +120,10 @@ export default class ProductReport {
     async finishLaunch(launchId) {
         if (!this.connected) return;
         await this.finishFixture();
-        await this.rpClient.finishLaunch(launchId, {
+        await (this.rpClient.finishLaunch(launchId, {
             end_time: this.rpClient.helpers.now()
+        })).promise.then((val) => {
+            console.log('Report Portal launch: ' + val.link);
         });
     }
 


### PR DESCRIPTION
I have noticed that if we could dump a link to the launch with each test run, it would make the test results (from Jenkins or an IDE) very accessible.

But because the test results (screenshots and spec details) are logged in a separate place - i.e. Report Portal from where they are running, there exists this extra step to now having to navigate to Report Portal and manually locate the run using various tricks - launch time, tag, launch name etc.

I feel we can provide a link to the launch - may be in the `finishLaunch()` part of the code, to alleviate this problem.

This is how the output looks in CLI:
![image](https://user-images.githubusercontent.com/72095121/111376741-3ba71280-8676-11eb-8c27-bed1cb9da74f.png)