### PR TITLE
Add the ability to manually specify an existing launch to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ REPORT_PORTAL_LAUNCH_NAME=The Launch Name
 REPORT_PORTAL_TAGS=Tag1, Tag2
 # Description is optional
 REPORT_PORTAL_DESCRIPTION=Run description
+# Launch ID is optional, and if specified the reporter will use the specified ID for its launch, and will not stop the launch at the end of the suite
+REPORT_PORTAL_LAUNCH_ID=XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-reporter-reportportal",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "description": "TestCafe reporter plugin for reportportal.io",
   "repository": "https://github.com/redfox256/testcafe-reporter-reportportal",
   "author": {

--- a/src/productreport.js
+++ b/src/productreport.js
@@ -10,6 +10,7 @@ export default class ProductReport {
     constructor() {
         this.projectName = process.env.REPORT_PORTAL_PROJECT_NAME;
         this.launchName = process.env.REPORT_PORTAL_LAUNCH_NAME || this.projectName;
+        this.manualLaunchId = process.env.REPORT_PORTAL_LAUNCH_ID;
         this.description = typeof process.env.REPORT_PORTAL_DESCRIPTION === 'undefined' ? void 0 : process.env.REPORT_PORTAL_DESCRIPTION;
         this.tagsList = typeof process.env.REPORT_PORTAL_TAGS === 'undefined' ? void 0 : process.env.REPORT_PORTAL_TAGS.split(',');
         this.fixtureList = [];
@@ -38,7 +39,8 @@ export default class ProductReport {
         const launchObj = this.rpClient.startLaunch({
             name: this.launchName,
             description: this.description,
-            tags: this.tagsList
+            tags: this.tagsList,
+            id: this.manualLaunchId
         });
 
         return launchObj.tempId;
@@ -120,11 +122,14 @@ export default class ProductReport {
     async finishLaunch(launchId) {
         if (!this.connected) return;
         await this.finishFixture();
-        await (this.rpClient.finishLaunch(launchId, {
-            end_time: this.rpClient.helpers.now()
-        })).promise.then((val) => {
-            console.log('Report Portal launch: ' + val.link);
-        });
+        
+        if (!this.manualLaunchId) {
+            await (this.rpClient.finishLaunch(launchId, {
+                end_time: this.rpClient.helpers.now()
+            })).promise.then((val) => {
+                console.log('Report Portal launch: ' + val.link);
+            });
+        }
     }
 
 }


### PR DESCRIPTION
When manually orchestrating multiple TestCafe instances, it's currently not possible to have all the separate test runs report to the same launch in Report Portal. This PR adds an env var to specify an existing launch ID, allowing the user to handle launch creation/deletion.